### PR TITLE
[data] allow affordance to reset the data on the frontend

### DIFF
--- a/cypress/e2e/CarLeaderBoard.cy.js
+++ b/cypress/e2e/CarLeaderBoard.cy.js
@@ -182,27 +182,53 @@ describe('Delete All Data & Start New Race button', () => {
     cy.seedDBAll('finals')
     cy.seedDBRaw('results-committed', true)
     cy.reload()
+    cy.on('window:confirm', () => false);
 
     containsInOrder([ "1st Place", "2nd Place", "3rd Place", "4th Place", "5th Place", "6th Place", "7th Place", "8th Place", "9th Place", "10th Place", "11th Place", "12th Place", "13th Place" ])
     
-    // clicking cancel should cancel the delete
-    cy.on('window:confirm', () => false);
-    cy.shadowFind('car-leader-board', '[name="delete-race-data"]')
-    .click()
+    
+    // all the data
+    cy.shadowFind('car-leader-board', 'clear-data-button#clearEverything', '[name="delete-all"]')
+      .click()
+
+    // just race information
+    cy.shadowFind('car-leader-board', 'clear-data-button#clearRaceData', '[name="delete-race-data"]')
+      .click()
   })
   
   it('clicking ok should execute the delete', () => {
     cy.seedDBAll('finals')
     cy.seedDBRaw('results-committed', true)
     cy.reload()
+    cy.on('window:confirm', () => true);
     
     containsInOrder([ "1st Place", "2nd Place", "3rd Place", "4th Place", "5th Place", "6th Place", "7th Place", "8th Place", "9th Place", "10th Place", "11th Place", "12th Place", "13th Place" ])
 
-    // clicking cancel should cancel the delete
-    cy.on('window:confirm', () => true);
-    cy.shadowFind('car-leader-board', '[name="delete-race-data"]')
-    .click()
-    
+    // just the race information
+    cy.shadowFind('car-leader-board', 'clear-data-button#clearRaceData', '[name="delete-race-data"]')
+      .click()
+      
+    // should still show the cars
+    containsInOrder([
+      "Fast Boi",
+      "Good Lookin'",
+      "slim jim",
+      "pizza",
+      "taco",
+      "bacon",
+      "lobster",
+      "cat mobile",
+      "dogsRule",
+      "snake on a car",
+      "car",
+      "burgermobile",
+      "pinecar",
+    ])
+      
+    // all the data
+    cy.shadowFind('car-leader-board', 'clear-data-button#clearEverything', '[name="delete-all"]')
+      .click()
+      
     cy.shadowFind('car-leader-board', '#message')
       .contains('please visit the main page to register')
   })

--- a/public/cars.html
+++ b/public/cars.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Racer.pi | Cars</title>
-  <link rel="stylesheet" href="/styles.css">
   <script src="/ws.js" type="module"></script>
 </head>
 <body>

--- a/public/cars/main.js
+++ b/public/cars/main.js
@@ -1,6 +1,7 @@
 import { WebComponent, wc, css, dom, register, attach } from '../dom.js'
 import { localStorage } from '../storage.js';
 import { formatOrdinals } from '../util.js';
+import ClearDataButton from '../views/ClearDataButton.js';
 
 import '../debug.js'
 
@@ -160,8 +161,9 @@ const template = wc`
   <table id="cars"></table>
   <div id="after-race" class="hidden">
     <button name="download">Save Race & Download CSV</button>
-    <button name="delete-race-data">Delete All Data & Start New Race</button>
   </div>
+  <${ClearDataButton.is} id="clearEverything" all></${ClearDataButton.is}>
+  <${ClearDataButton.is} id="clearRaceData"></${ClearDataButton.is}>
 `
 
 const car = ({ id, name="", weight="" }) => dom`
@@ -393,16 +395,6 @@ export default class CarLeaderBoard extends WebComponent {
         
         downloadUrl && window.open(downloadUrl)
       })
-  }
-
-  onClickDeleteRaceData () {
-    const shouldClear = window.confirm(
-      'This action will remove all race and car data, are you sure you want to continue?'
-    )
-    if (shouldClear) {
-      localStorage.clear()
-      window.location.reload()
-    }
   }
 }
 

--- a/public/globalStyles.js
+++ b/public/globalStyles.js
@@ -1,0 +1,19 @@
+export function css (...args) {
+  return `<style>${String.raw(...args)}</style>`
+}
+
+export default css`
+  button:not([no-styles]) {
+    padding: 10px 20px;
+    margin: 5px;
+    border: 1px solid black;
+    border-radius: 5px;
+    background-color: #eee;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+  }
+
+  button:not([no-styles]):hover {
+    background-color: white;
+  }
+`

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Racer.pi</title>
-  <link rel="stylesheet" href="styles.css">
   <script src="ws.js" type="module"></script>
 </head>
 <body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,3 +1,0 @@
-#race-title {
-  text-decoration: underline;
-}

--- a/public/views/CarConfig.js
+++ b/public/views/CarConfig.js
@@ -2,6 +2,8 @@ import env from '/env'
 import { WebComponent, wc, dom, register, css } from '../dom.js'
 import { localStorage } from '../storage.js';
 
+import ClearDataButton from './ClearDataButton.js';
+
 const styles = css`
   .button-row {
     display: flex;
@@ -27,15 +29,15 @@ const template = wc`
   <div class="button-row">
     <button name="add-car">Add Car</button>
     <button name="start-race">Start Race</button>
-    <button name="clear">Clear All</button>
   </div>
+  <${ClearDataButton.is} all=""></${ClearDataButton.is}>
 `
 
 const car = ({ id, name="", weight="" }) => dom`
   <li class="car">
     <label class="name">Car Name: <input id="${id}" type="text" name="car-name" value="${name}"/></label>
     <label class="weight">Weight: <input id="${id}-weight" type="number" name="car-weight" value="${weight}"/>oz</label>
-    <button name="remove-car" title="Remove Car" data-id="${id}">X</button>
+    <button name="remove-car" title="Remove Car" data-id="${id}" no-styles>X</button>
   </li>
 `
 
@@ -100,16 +102,6 @@ export default class CarConfig extends WebComponent {
     })
     localStorage.set(CarConfig.is, this.cars)
     document.dispatchEvent(new CustomEvent('view-round-one'))
-  }
-
-  onClickClear() {
-    const shouldClear = window.confirm(
-      'This action will remove all race and car data, are you sure you want to continue?'
-    )
-    if (shouldClear) {
-      localStorage.clear()
-      window.location.reload()
-    }
   }
 }
 

--- a/public/views/ClearDataButton.js
+++ b/public/views/ClearDataButton.js
@@ -1,0 +1,60 @@
+import { WebComponent, dom, css, register } from '../dom.js'
+import { localStorage } from '../storage.js';
+
+const styles = css`
+  button.delete-button {
+    margin: 50px;
+    float: right;
+    border: 1px solid red;
+    opacity: 0.3;
+  }
+  
+  button.delete-button:hover {
+    background-color: red;
+    color: white;
+    opacity: 1;
+  }
+`
+
+export default class ClearDataButton extends WebComponent {
+  static is = 'clear-data-button';
+  static observedAttributes = ['all'];
+  constructor () {
+    super(() => dom`
+      ${(console.log(this.attrs), styles)}
+      <button class="delete-button" name="${this.attrs.all ? 'delete-all' : 'delete-race-data'}">
+        ${this.attrs.all ? 'Delete All Data & Start New Race' : 'Delete All Race Data'}
+      </button>
+    `, { defer: true })
+    this.render()
+  }
+
+  shouldClear () {
+    const { all } = this.attrs
+
+    return window.confirm(
+      (all
+        ? 'This action will remove all information, including car names, weights, race results, etc.'
+        : 'This action will remove all race data. Car information such as the names and weights of the cars will be retained.'
+      ) + '\n\nThis action cannot be undone. Are you sure you want to continue?'
+    )
+  }
+
+  onClickDeleteRaceData () {
+    if (this.shouldClear()) {
+      const cars = localStorage.get('car-group', {})
+      localStorage.clear()
+      localStorage.set('car-group', cars)
+      window.location.reload()
+    }
+  }
+
+  onClickDeleteAll () {
+    if (this.shouldClear()) {
+      localStorage.clear()
+      window.location.reload()
+    }
+  }
+}
+
+register(ClearDataButton)

--- a/public/views/EliminationRound.js
+++ b/public/views/EliminationRound.js
@@ -4,6 +4,7 @@ import CarConfig from './CarConfig.js'
 import { localStorage } from '../storage.js'
 import { Timer } from '../timer.js'
 import { deferredAction, formatOrdinals } from '../util.js'
+import ClearDataButton from './ClearDataButton.js';
 
 const totalLanes = env.LANE_COUNT
 const halfOfTheLanes = Math.floor(totalLanes/2)
@@ -57,6 +58,7 @@ const template = wc`
   <slot name="start-message"></slot>
   <pre id="timer"></pre>
   <div id="heats"></div>
+  <${ClearDataButton.is}></${ClearDataButton.is}>
 `
 
 export default class EliminationRound extends WebComponent {

--- a/public/views/FinalRound.js
+++ b/public/views/FinalRound.js
@@ -6,6 +6,7 @@ import CarConfig from './CarConfig.js';
 import LaneEventWC from './LaneEventWC.js';
 import TimerComponent from './Timer.js';
 import { deferredAction } from '../util.js';
+import ClearDataButton from './ClearDataButton.js';
 
 const totalLanes = env.LANE_COUNT
 
@@ -55,6 +56,8 @@ const template = wc`
 
     <button name="continue">Begin Finals</button>
   </div>
+
+  <${ClearDataButton.is}></${ClearDataButton.is}>
 `
 
 export default class FinalRound extends LaneEventWC {


### PR DESCRIPTION
@ddkzwest pointed out that there is no way to reset the system state in the GUI. This PR adds context buttons to let you clear out all race data, and in some situations, clear out all car information as well.

<img width="628" alt="Screenshot 2023-11-10 at 8 13 22 AM" src="https://github.com/kyle-west/racer.pi/assets/18150457/544adfa8-039a-4878-8391-df57660376f5">

While I was in here, I added a concept of globalStyles that reaches past the shadow dom. This is for future styling work.
